### PR TITLE
fix: approvals from committers require two approvals

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ You can address these loopholes by running this action via `pull_request_review`
 
 This action performs the following validations:
 
-- The latest commit in the PR must be approved by someone who didn't contribute commits to the PR
+- The latest commit of the PR must be approved
 - Approvals from GitHub Apps or untrusted machine users are ignored
 
 In the following cases, two or more approvals are required:
 
+- Someone who contributed commits to the PR approves the latest commit of the PR
 - If any of the commits were made by an **untrusted** machine user or a GitHub App (excluding a few **trusted** ones)
 - If the pull request was created by an untrusted machine user or GitHub App (excluding a few trusted ones)
 - If there are commits without a linked GitHub user

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -152,6 +152,7 @@ test("analyze - normal", () => {
     author: authors.octocat,
     trustedApprovals: [trustedApprovalFromSuzuki],
     ignoredApprovals: [],
+    approvalsFromCommitters: [],
     untrustedCommits: [],
     twoApprovalsAreRequired: false,
     valid: true,
@@ -179,6 +180,7 @@ test("analyze - at least one approval is required", () => {
     trustedApprovals: [],
     ignoredApprovals: [],
     untrustedCommits: [],
+    approvalsFromCommitters: [],
     twoApprovalsAreRequired: false,
     message: "At least one approval is required",
     valid: false,
@@ -206,6 +208,7 @@ test("analyze - pr author is a trusted app", () => {
     trustedApprovals: [trustedApprovalFromSuzuki],
     ignoredApprovals: [],
     untrustedCommits: [],
+    approvalsFromCommitters: [],
     twoApprovalsAreRequired: false,
     valid: true,
   });
@@ -235,6 +238,7 @@ test("analyze - pr author is an untrusted machine user", () => {
     trustedApprovals: [trustedApprovalFromSuzuki],
     ignoredApprovals: [],
     untrustedCommits: [],
+    approvalsFromCommitters: [],
     twoApprovalsAreRequired: true,
     valid: false,
     message: "At least two approvals are required",
@@ -265,6 +269,7 @@ test("analyze - pr author is an untrusted machine user (regexp)", () => {
     trustedApprovals: [trustedApprovalFromSuzuki],
     ignoredApprovals: [],
     untrustedCommits: [],
+    approvalsFromCommitters: [],
     twoApprovalsAreRequired: true,
     valid: false,
     message: "At least two approvals are required",
@@ -300,6 +305,7 @@ test("analyze - trusted_machine_users", () => {
     trustedApprovals: [trustedApprovalFromSuzuki],
     ignoredApprovals: [],
     untrustedCommits: [],
+    approvalsFromCommitters: [],
     twoApprovalsAreRequired: false,
     valid: true,
   });
@@ -332,6 +338,7 @@ test("analyze - pr author is an untrusted machine user (2 approvals)", () => {
     trustedApprovals: [trustedApprovalFromSuzuki, trustedApprovalFromSuzuki2],
     ignoredApprovals: [],
     untrustedCommits: [],
+    approvalsFromCommitters: [],
     twoApprovalsAreRequired: true,
     valid: true,
   });
@@ -360,6 +367,7 @@ test("analyze - pr author is an untrusted app", () => {
     },
     trustedApprovals: [trustedApprovalFromSuzuki],
     ignoredApprovals: [],
+    approvalsFromCommitters: [],
     untrustedCommits: [],
     twoApprovalsAreRequired: true,
     valid: false,
@@ -409,12 +417,6 @@ test("analyze - filter reviews", () => {
     trustedApprovals: [],
     ignoredApprovals: [
       {
-        message: "approval from committer is ignored",
-        user: {
-          login: "suzuki-shunsuke",
-        },
-      },
-      {
         message: "approval from app is ignored",
         user: {
           login: "suzuki-shunsuke-app",
@@ -427,8 +429,16 @@ test("analyze - filter reviews", () => {
         },
       },
     ],
+    approvalsFromCommitters: [
+      {
+        message: "approval from committer requires two approvals",
+        user: {
+          login: "suzuki-shunsuke",
+        },
+      },
+    ],
     untrustedCommits: [],
-    twoApprovalsAreRequired: false,
+    twoApprovalsAreRequired: true,
     valid: false,
     message: "At least one approval is required",
   });
@@ -454,6 +464,7 @@ test("analyze - not linked user", () => {
     author: authors.octocat,
     trustedApprovals: [trustedApprovalFromSuzuki],
     ignoredApprovals: [],
+    approvalsFromCommitters: [],
     untrustedCommits: [
       {
         sha: latestSHA,
@@ -484,6 +495,7 @@ test("analyzeReviews - normal", () => {
     ),
   ).toStrictEqual({
     trusted: [trustedApprovalFromSuzuki],
+    approvalsFromCommitters: [],
     ignored: [],
   });
 });

--- a/src/run.ts
+++ b/src/run.ts
@@ -157,7 +157,9 @@ export const analyze = (pr: type.PullRequest, input: lib.Input): Result => {
     approvalsFromCommitters: approvals.approvalsFromCommitters,
     untrustedCommits: untrustedCommits.untrusted,
     twoApprovalsAreRequired:
-      untrustedCommits.untrusted.length > 0 || author.untrusted || approvals.approvalsFromCommitters.length > 0,
+      untrustedCommits.untrusted.length > 0 ||
+      author.untrusted ||
+      approvals.approvalsFromCommitters.length > 0,
     author: author,
     valid: true,
   };
@@ -307,25 +309,25 @@ const validateCommitter = (
     return input.trustedApps.has(user.resourcePath)
       ? undefined
       : {
+          sha: commit.oid,
+          committer: {
+            login: user.login,
+            untrusted: true,
+            message: "untrusted app",
+          },
+          message: "the committer is an untrusted app",
+        };
+  }
+  return matchUntrustedMachineUser(user.login, input)
+    ? {
         sha: commit.oid,
         committer: {
           login: user.login,
           untrusted: true,
-          message: "untrusted app",
+          message: "untrusted machine user",
         },
-        message: "the committer is an untrusted app",
-      };
-  }
-  return matchUntrustedMachineUser(user.login, input)
-    ? {
-      sha: commit.oid,
-      committer: {
-        login: user.login,
-        untrusted: true,
-        message: "untrusted machine user",
-      },
-      message: "the committer is an untrusted machine user",
-    }
+        message: "the committer is an untrusted machine user",
+      }
     : undefined;
 };
 


### PR DESCRIPTION
This pull request fixes a bug that approvals from committers are ignored.
If two or more people approve a pull request, this action should be passed even if committers approve.