### PR TITLE
feat: use action_required status when no approvals

### DIFF
--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -181,7 +181,8 @@ test("analyze - at least one approval is required", () => {
     approvalsFromCommitters: [],
     twoApprovalsAreRequired: false,
     message: "At least one approval is required",
-    valid: false,
+    valid: true,
+    requiresAction: true,
   });
 });
 


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://github.com/suzuki-shunsuke/validate-pr-review-action/blob/main/CONTRIBUTING.md)
- [ ] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue:
- [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)

<!-- Please write the description here -->

現在の実装では、PRに承認が1つもない場合、GitHub Actionsが失敗として扱われます。
action_required ステータスに変更することで、commentによるfail通知を抑えて、requiredも防ぐことが可能になります

Translated by Gemini:

In the current implementation, GitHub Actions will fail if a PR doesn't have at least one approval.
By changing the status to action_required, you can prevent the failure notification via comment and also prevent it from being a required check.